### PR TITLE
Fix syscall compatibility for newer architectures

### DIFF
--- a/src/dup.c
+++ b/src/dup.c
@@ -34,13 +34,23 @@ int dup2 (int old, int new) {
 
     /* Don't allow overwriting of stdin/stdout */
     if (LIKELY(r > 1)) {
+        #ifdef SYS_dup2
         while ((r = __syscall(SYS_dup2, old, new)) == -EBUSY) ;
+        #else
+        /* Use dup3 with flags=0 to emulate dup2 */
+        while ((r = __syscall(SYS_dup3, old, new, 0)) == -EBUSY) ;
+        #endif
     }
 #ifdef DUP_STDIN
     /* except in this case do allow overwriting of stdin*/
     else if (r==0) {
         DEBUG_LOG("Overwriting stdin...");
+        #ifdef SYS_dup2
         while ((r = __syscall(SYS_dup2, old, new)) == -EBUSY) ;
+        #else
+        /* Use dup3 with flags=0 to emulate dup2 */
+        while ((r = __syscall(SYS_dup3, old, new, 0)) == -EBUSY) ;
+        #endif
     }
 #endif
     else {


### PR DESCRIPTION
- Add fallback to dup3() when dup2() is not available (aarch64, riscv64)
- Add fallback to ppoll() when poll() is not available
- Affects architectures like aarch64, riscv32/64, and other newer platforms that only have modern syscalls