### PR TITLE
Fix missing includes for syscall compatibility

### DIFF
--- a/src/poll.c
+++ b/src/poll.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #define __USE_GNU
 #include <poll.h>
+#include <stddef.h>  /* for NULL */
 
 #include "util.h"
 #include "desock.h"

--- a/src/select.c
+++ b/src/select.c
@@ -1,6 +1,7 @@
 #include <sys/select.h>
 #include <errno.h>
 #include <string.h>
+#include <signal.h>  /* for _NSIG */
 
 #include "util.h"
 #include "desock.h"


### PR DESCRIPTION
- Add stddef.h to poll.c for NULL definition
- Add signal.h to select.c for _NSIG definition
- Required for architectures using newer syscalls